### PR TITLE
Fix arbitrary value of target position and more

### DIFF
--- a/custom_components/cover_time_based_synced/cover.py
+++ b/custom_components/cover_time_based_synced/cover.py
@@ -132,6 +132,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._target_position = 0
         self._processing_known_position = False
         self._unique_id = device_id
+        self._switching = False
 
         if name:
             self._name = name
@@ -167,8 +168,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             return
 
         if self._switch_open_state == "off" and self._switch_close_state == "off":
-            _LOGGER.debug(self._name + ': ' + 'open/close: off/off, stopping')
-            self._handle_my_button()
+            if not self._switching:
+                _LOGGER.debug(self._name + ': ' + 'open/close: off/off, stopping')
+                self._handle_my_button()
         elif self._switch_open_state == "on" and self._switch_close_state == "on":
             _LOGGER.debug(self._name + ': ' + 'open/close: on/on, turning off both switches')
             self._handle_my_button()
@@ -194,6 +196,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 self._target_position = 0
                 self.tc.start_travel_down()
             self.start_auto_updater()
+
+        self._switching = False
             
 
     async def async_added_to_hass(self):
@@ -407,12 +411,14 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         if command == "close_cover":
             cmd = "DOWN"
             self._state = False
+            self._switching = True
             await self.hass.services.async_call("homeassistant", "turn_off", {"entity_id": self._open_switch_entity_id}, False)
             await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._close_switch_entity_id}, False)
 
         elif command == "open_cover":
             cmd = "UP"
             self._state = True
+            self._switching = True
             await self.hass.services.async_call("homeassistant", "turn_off", {"entity_id": self._close_switch_entity_id}, False)
             await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._open_switch_entity_id}, False)
 

--- a/custom_components/cover_time_based_synced/cover.py
+++ b/custom_components/cover_time_based_synced/cover.py
@@ -187,10 +187,10 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             self.start_auto_updater()
         elif self._switch_open_state == "off" and self._switch_close_state == "on":
             if self._target_position != 100 and self._target_position != 0:
-                _LOGGER.debug(self._name + ': ' + 'open/close: on/off, closing to %d', self._target_position)
+                _LOGGER.debug(self._name + ': ' + 'open/close: off/on, closing to %d', self._target_position)
                 self.tc.start_travel(self._target_position)
             else:
-                _LOGGER.debug(self._name + ': ' + 'open/close: on/off, closing to predefined 0')
+                _LOGGER.debug(self._name + ': ' + 'open/close: off/on, closing to predefined 0')
                 self._target_position = 0
                 self.tc.start_travel_down()
             self.start_auto_updater()

--- a/custom_components/cover_time_based_synced/cover.py
+++ b/custom_components/cover_time_based_synced/cover.py
@@ -234,7 +234,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         return "cover_timebased_synced_uuid_" + self._unique_id
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the device state attributes."""
         attr = {}
         if self._travel_time_down is not None:

--- a/custom_components/cover_time_based_synced/travelcalculator.py
+++ b/custom_components/cover_time_based_synced/travelcalculator.py
@@ -99,7 +99,7 @@ class TravelCalculator:
         if self.travel_direction == TravelStatus.DIRECTION_UP:
             return self.current_position() >= self.travel_to_position
         elif self.travel_direction == TravelStatus.DIRECTION_DOWN:
-            return self.current_position <= self.travel_to_position
+            return self.current_position() <= self.travel_to_position
         else:
             return self.current_position() == self.travel_to_position
 

--- a/custom_components/cover_time_based_synced/travelcalculator.py
+++ b/custom_components/cover_time_based_synced/travelcalculator.py
@@ -96,7 +96,12 @@ class TravelCalculator:
 
     def position_reached(self):
         """Return if cover has reached designated position."""
-        return self.current_position() == self.travel_to_position
+        if self.travel_direction == TravelStatus.DIRECTION_UP:
+            return self.current_position() >= self.travel_to_position
+        elif self.travel_direction == TravelStatus.DIRECTION_DOWN:
+            return self.current_position <= self.travel_to_position
+        else:
+            return self.current_position() == self.travel_to_position
 
     def is_open(self):
         """Return if cover is (fully) open."""


### PR DESCRIPTION
This fixes #3 and #4.

Furthermore during my testing I found another problem which should know be fixed:
Example: The cover is at 100% and the button to go up is still active (because someone forgot). If you now set a target position via HA the cover goes down to 0% because the state change of the buttons overwrites the target position. I added a helper variable to prevent this.