### PR TITLE
fix deprecation warning for entity service schemas

### DIFF
--- a/custom_components/cover_time_based_synced/cover.py
+++ b/custom_components/cover_time_based_synced/cover.py
@@ -69,7 +69,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-POSITION_SCHEMA = vol.Schema(
+POSITION_SCHEMA = cv.make_entity_service_schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(ATTR_POSITION): cv.positive_int,
@@ -79,7 +79,7 @@ POSITION_SCHEMA = vol.Schema(
 )
 
 
-ACTION_SCHEMA = vol.Schema(
+ACTION_SCHEMA = cv.make_entity_service_schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(ATTR_ACTION): cv.string


### PR DESCRIPTION
The messages in HA log were: 
`2024-11-01 18:19:58.438 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'cover_time_based_synced' registers an entity service with a non entity service schema which will stop working in HA Core 2025.9 at custom_components/cover_time_based_synced/cover.py, line 114: platform.async_register_entity_service(, please create a bug report at https://github.com/kotborealis/home-assistant-custom-components-cover-time-based-synced/issues
2024-11-01 18:19:58.441 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'cover_time_based_synced' registers an entity service with a non entity service schema which will stop working in HA Core 2025.9 at custom_components/cover_time_based_synced/cover.py, line 118: platform.async_register_entity_service(, please create a bug report at https://github.com/kotborealis/home-assistant-custom-components-cover-time-based-synced/issues`

These changes are fixing the problem.